### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/infinite-scroll/index.html
+++ b/src/infinite-scroll/index.html
@@ -1,5 +1,5 @@
-<gb-infinite-list items="{ state.items }" layout="grid">
+<gb-infinite-list items="{state.items}" layout="grid">
   <yield>
-    <gb-product product="{ item }"></gb-product>
+    <gb-product product="{item}"></gb-product>
   </yield>
 </gb-infinite-list>

--- a/src/loader/index.html
+++ b/src/loader/index.html
@@ -1,1 +1,1 @@
-<span>{ $infinite.loaderLabel }</span>
+<span>{$infinite.loaderLabel}</span>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.